### PR TITLE
Half baked energy calculation for periodic systems

### DIFF
--- a/src/chemistry/chemistry_utils.h
+++ b/src/chemistry/chemistry_utils.h
@@ -31,6 +31,7 @@
 namespace mrchem {
 namespace chemistry {
 double compute_nuclear_repulsion(const Nuclei &nucs);
-Density compute_nuclear_density(double prec, const Nuclei &nucs, double alpha);
+void compute_nuclear_density(double prec, Density &rho, const Nuclei &nucs, double alpha);
+double compute_nuclear_self_repulsion(const Nuclei &nucs, double alpha);
 } // namespace chemistry
 } // namespace mrchem

--- a/src/mrenv.cpp
+++ b/src/mrenv.cpp
@@ -61,8 +61,8 @@ void initialize(int argc, char **argv) {
     std::copy_n(boxes.begin(), 3, n_bxs.begin());
     std::copy_n(scaling_factor.begin(), 3, sf.begin());
 
-    // BoundingBox<3> world(min_scale, c_idx, n_bxs);
-    BoundingBox<3> world(sf, periodic);
+    BoundingBox<3> world(min_scale, c_idx, n_bxs);
+    //BoundingBox<3> world(sf, periodic);
     // Initialize scaling basis
     int order = Input.get<int>("MRA.order");
     string btype = Input.get<string>("MRA.basis_type");

--- a/src/qmoperators/two_electron/CoulombOperator.h
+++ b/src/qmoperators/two_electron/CoulombOperator.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include "chemistry/chemistry_utils.h"
 #include "CoulombPotential.h"
 #include "CoulombPotentialD1.h"
 #include "CoulombPotentialD2.h"
 #include "HartreePotential.h"
 #include "qmoperators/RankZeroTensorOperator.h"
+#include "qmfunctions/qmfunction_utils.h"
 
 /** @class CoulombOperator
  *
@@ -42,12 +44,20 @@ public:
         if (this->potential != nullptr) delete this->potential;
     }
 
+    const Nuclei &getNuclei() const { return this->potential->getNuclei(); }
+
     Density &getDensity() {
         if (potential != nullptr) return this->potential->getDensity();
         MSG_FATAL("Coulomb operator not properly initialized");
     }
 
     ComplexDouble trace(OrbitalVector &Phi) { return 0.5 * RankZeroTensorOperator::trace(Phi); }
+    ComplexDouble trace(const Nuclei &nucs) {
+        QMFunction &V = *this->potential;
+        Density rho_nuc(false);
+        chemistry::compute_nuclear_density(this->potential->prec(), rho_nuc, nucs, 1.0e6);
+        return 0.5 * qmfunction::dot(V, rho_nuc);
+    }
 
 private:
     CoulombPotential *potential;

--- a/src/qmoperators/two_electron/CoulombPotential.h
+++ b/src/qmoperators/two_electron/CoulombPotential.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "chemistry/Nucleus.h"
 #include "qmfunctions/Density.h"
 #include "qmoperators/one_electron/QMPotential.h"
 
@@ -31,11 +32,14 @@ public:
     friend class CoulombOperator;
 
 protected:
+    Nuclei nuclei{};
     Density density;                 ///< Ground-state electron density
     mrcpp::PoissonOperator *poisson; ///< Operator used to compute the potential
 
     Density &getDensity() { return this->density; }
     bool hasDensity() const { return (this->density.squaredNorm() < 0.0) ? false : true; }
+
+    const Nuclei &getNuclei() const { return this->nuclei; }
 
     void setup(double prec);
     void clear();

--- a/src/qmoperators/two_electron/FockOperator.cpp
+++ b/src/qmoperators/two_electron/FockOperator.cpp
@@ -178,9 +178,8 @@ ComplexMatrix FockOperator::operator()(OrbitalVector &bra, OrbitalVector &ket) {
     if (v.size() > 0) V += v(bra, ket);
     t_pot.stop();
     Printer::printDouble(0, "Potential part", t_pot.getWallTime());
-    println(0, T) println(0, V)
 
-        t_tot.stop();
+    t_tot.stop();
     Printer::printFooter(0, t_tot, 2);
     return T + V;
 }

--- a/src/qmoperators/two_electron/FockOperator.cpp
+++ b/src/qmoperators/two_electron/FockOperator.cpp
@@ -130,12 +130,16 @@ SCFEnergy FockOperator::trace(OrbitalVector &Phi, const ComplexMatrix &F) {
 
     // Nuclear part
     if (this->nuc != nullptr) {
-        Nuclei &nucs = this->nuc->getNuclei();
+        const Nuclei &nucs = this->nuc->getNuclei();
         E_nuc = chemistry::compute_nuclear_repulsion(nucs);
         if (this->ext != nullptr) {
             E_nex = this->ext->trace(nucs).real();
             E_nuc += E_nex;
         }
+    } else if (this->coul != nullptr) {
+        const Nuclei &nucs = this->coul->getNuclei();
+        E_nuc = 0.5*chemistry::compute_nuclear_self_repulsion(nucs, 1.0e6);
+        E_en = this->coul->trace(nucs).real();
     }
 
     // Orbital energies
@@ -143,6 +147,8 @@ SCFEnergy FockOperator::trace(OrbitalVector &Phi, const ComplexMatrix &F) {
         double occ = (double)Phi[i].occ();
         E_orb += occ * F(i, i).real();
     }
+
+
 
     // Electronic part
     if (this->nuc != nullptr) E_en = this->nuc->trace(Phi).real();
@@ -156,6 +162,15 @@ SCFEnergy FockOperator::trace(OrbitalVector &Phi, const ComplexMatrix &F) {
     double E_orbxc2 = E_orb - E_xc2;
     E_kin = E_orbxc2 - 2.0 * E_eex - E_en - E_ext;
     E_el = E_orbxc2 - E_eex + E_xc;
+
+    println(0, "E_orb: " << E_orb);
+    println(0, "E_en:  " << E_en);
+    println(0, "E_ee:  " << E_ee);
+    println(0, "E_nuc: " << E_nuc);
+    println(0, "E_xc:  " << E_xc);
+    println(0, "E_xc2: " << E_xc2);
+    double E_tot = E_orb - E_en - E_ee - E_nuc + E_xc - E_xc2;
+    println(0, "TOTAL ENERGY: " << E_tot);
 
     return SCFEnergy{E_nuc, E_el, E_orb, E_kin, E_en, E_ee, E_xc, E_x, E_nex, E_ext};
 }

--- a/src/qmoperators/two_electron/HartreePotential.cpp
+++ b/src/qmoperators/two_electron/HartreePotential.cpp
@@ -29,8 +29,9 @@ namespace mrchem {
 
 HartreePotential::HartreePotential(PoissonOperator *P, OrbitalVector *Phi, const Nuclei &nucs)
         : CoulombPotential(P)
-        , nuclei(nucs)
-        , orbitals(Phi) {}
+        , orbitals(Phi) {
+    this->nuclei = nucs;
+}
 
 void HartreePotential::setupDensity(double prec) {
     if (hasDensity()) return;
@@ -42,8 +43,12 @@ void HartreePotential::setupDensity(double prec) {
     Timer timer;
     Density rho_el(false);
     density::compute(prec, rho_el, Phi, DENSITY::Total);
-    Density rho_nuc = chemistry::compute_nuclear_density(this->apply_prec, this->nuclei, 1.0e4);
+    Density rho_nuc(false);
+    chemistry::compute_nuclear_density(this->apply_prec, rho_nuc, this->nuclei, 1.0e6);
     qmfunction::add(rho, 1.0, rho_el, -1.0, rho_nuc, -1.0);
+    println(0, "nuc_charge " << rho_nuc.integrate());
+    println(0, "el_charge  " << rho_el.integrate());
+    println(0, "tot_charge " << rho.integrate());
 
     timer.stop();
     double t = timer.getWallTime();

--- a/src/qmoperators/two_electron/HartreePotential.cpp
+++ b/src/qmoperators/two_electron/HartreePotential.cpp
@@ -43,9 +43,7 @@ void HartreePotential::setupDensity(double prec) {
     Density rho_el(false);
     density::compute(prec, rho_el, Phi, DENSITY::Total);
     Density rho_nuc = chemistry::compute_nuclear_density(this->apply_prec, this->nuclei, 1.0e4);
-    println(0, "Not zero? " << rho_nuc.integrate());
     qmfunction::add(rho, 1.0, rho_el, -1.0, rho_nuc, -1.0);
-    println(0, "is this zero? " << rho.integrate());
 
     timer.stop();
     double t = timer.getWallTime();

--- a/src/qmoperators/two_electron/HartreePotential.h
+++ b/src/qmoperators/two_electron/HartreePotential.h
@@ -28,7 +28,6 @@ public:
     virtual ~HartreePotential() = default;
 
 private:
-    Nuclei nuclei;
     OrbitalVector *orbitals; ///< Unperturbed orbitals defining the ground-state electron density
 
     void setupDensity(double prec);


### PR DESCRIPTION
The final energy printout is the same old faulty one, but there's an extra `TOTAL ENERGY: ` printout in the middle of each SCF cycle that should be correct.